### PR TITLE
fix: prevent crash when all groups are deleted

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,7 @@ function App() {
     try {
       const response = await fetch('http://localhost:3001/api/users')
       const userData = await response.json()
-      setUsers(userData)
+      setUsers(userData || [])
       
       // Initialize current user from localStorage or default to first user
       const savedUserId = localStorage.getItem('selectedUserId')

--- a/frontend/src/components/ShareDialog.jsx
+++ b/frontend/src/components/ShareDialog.jsx
@@ -63,7 +63,7 @@ function ShareDialog({ isOpen, onClose, resourceType, resourceId, currentUser })
 
       if (usersResponse.ok) {
         const usersData = await usersResponse.json()
-        setUsers(usersData)
+        setUsers(usersData || [])
       } else {
         console.error('Failed to fetch users from groups service')
         setUsers([])
@@ -71,7 +71,7 @@ function ShareDialog({ isOpen, onClose, resourceType, resourceId, currentUser })
 
       if (groupsResponse.ok) {
         const groupsData = await groupsResponse.json()
-        setGroups(groupsData)
+        setGroups(groupsData || [])
       } else {
         console.error('Failed to fetch groups from groups service')
         setGroups([])

--- a/frontend/src/pages/DocsPage.jsx
+++ b/frontend/src/pages/DocsPage.jsx
@@ -14,7 +14,7 @@ function DocsPage({ currentUser }) {
         }
       })
       const data = await response.json()
-      setDocuments(data)
+      setDocuments(data || [])
     } catch (error) {
       console.error('Error fetching documents:', error)
     }

--- a/frontend/src/pages/GroupDetailPage.jsx
+++ b/frontend/src/pages/GroupDetailPage.jsx
@@ -22,7 +22,7 @@ function GroupDetailPage({ currentUser }) {
           'X-Username': currentUser.username
         }
       })
-      const groups = await response.json()
+      const groups = (await response.json()) || []
       const groupDetail = groups.find(g => g.username === username)
       
       if (groupDetail) {
@@ -53,7 +53,7 @@ function GroupDetailPage({ currentUser }) {
       
       if (response.ok) {
         const data = await response.json()
-        setMembers(data)
+        setMembers(data || [])
       } else {
         console.error('Error fetching group members:', response.statusText)
       }
@@ -66,7 +66,7 @@ function GroupDetailPage({ currentUser }) {
     try {
       const response = await fetch('http://localhost:3001/api/users')
       const userData = await response.json()
-      setUsers(userData)
+      setUsers(userData || [])
     } catch (error) {
       console.error('Error fetching users:', error)
     }

--- a/frontend/src/pages/GroupsPage.jsx
+++ b/frontend/src/pages/GroupsPage.jsx
@@ -20,7 +20,7 @@ function GroupsPage({ currentUser }) {
         }
       })
       const data = await response.json()
-      setGroups(data)
+      setGroups(data || [])
     } catch (error) {
       console.error('Error fetching groups:', error)
     }

--- a/frontend/src/pages/MailPage.jsx
+++ b/frontend/src/pages/MailPage.jsx
@@ -14,7 +14,7 @@ function MailPage({ currentUser }) {
         }
       })
       const data = await response.json()
-      setEmails(data)
+      setEmails(data || [])
     } catch (error) {
       console.error('Error fetching emails:', error)
     }

--- a/groups-service/.gitignore
+++ b/groups-service/.gitignore
@@ -1,0 +1,2 @@
+# compiled binary
+/groups-service

--- a/groups-service/main.go
+++ b/groups-service/main.go
@@ -459,7 +459,7 @@ func getGroups(c *gin.Context) {
 	}
 	defer rows.Close()
 
-	var groups []Group
+	groups := []Group{}
 	for rows.Next() {
 		var group Group
 		var createdAt time.Time
@@ -595,7 +595,7 @@ func getGroupMembersFromSpiceDB(groupUsername string) ([]map[string]string, erro
 		return nil, err
 	}
 
-	var members []map[string]string
+	members := []map[string]string{}
 	for {
 		response, err := stream.Recv()
 		if err != nil {
@@ -644,7 +644,7 @@ func getGroupOwnersFromSpiceDB(groupUsername string) ([]string, error) {
 		return nil, err
 	}
 
-	var owners []string
+	owners := []string{}
 	for {
 		response, err := stream.Recv()
 		if err != nil {
@@ -693,7 +693,7 @@ func getPublicGroups(c *gin.Context) {
 		CreatedAt   string `json:"created_at"`
 	}
 
-	var groups []PublicGroup
+	groups := []PublicGroup{}
 	for rows.Next() {
 		var group PublicGroup
 		var createdAt time.Time
@@ -812,7 +812,7 @@ func getGroupMembers(c *gin.Context) {
 		Role     string `json:"role"`
 	}
 
-	var members []Member
+	members := []Member{}
 	for _, memberInfo := range memberData {
 		members = append(members, Member{
 			Username: memberInfo["username"],


### PR DESCRIPTION
Fixes #1.

Deleting all groups crashed the frontend: Go handlers built result slices as `var x []T`, which serialize to JSON `null` when empty, and the React app called `.map()` on `null`.

- groups-service: initialize the 5 response slices as `[]T{}` so empty results serialize as `[]`.
- frontend: guard list setters with `|| []` (the app also talks to Java/Node services, so it can't assume every backend returns `[]`).
- gitignore an accidentally-committed compiled binary.

Verified end-to-end on the docker-compose stack: on `main`, deleting all groups makes `GET /groups` return `null` and the UI crash ("Cannot read properties of null (reading 'map')"); on this branch it returns `[]` and does not crash.